### PR TITLE
Improve Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,7 @@ release:
 docs:
 	go run github.com/hymkor/minipage@latest README.md > "docs/index.html"
 
+readme:
+	go run github.com/hymkor/example-into-readme@latest
+
 .PHONY: all test dist _dist clean manifest release docs

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean:
 	$(DEL) *.zip $(NAME)$(EXE)
 
 manifest:
-	make-scoop-manifest *-windows-*.zip > $(NAME).json
+	$(GO) run github.com/hymkor/make-scoop-manifest@latest *-windows-*.zip > $(NAME).json
 
 release:
 	pwsh -Command "latest-notes.ps1" | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,6 @@ release:
 	$(GO) run github.com/hymkor/latest-notes@latest | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
 docs:
-	minipage README.md > "docs/index.html"
+	go run github.com/hymkor/minipage@latest README.md > "docs/index.html"
 
 .PHONY: all test dist _dist clean manifest release docs

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ manifest:
 	$(GO) run github.com/hymkor/make-scoop-manifest@latest *-windows-*.zip > $(NAME).json
 
 release:
-	pwsh -Command "latest-notes.ps1" | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
+	$(GO) run github.com/hymkor/latest-notes@latest | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
 docs:
 	minipage README.md > "docs/index.html"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 # GQuaccccccesS
 
+<!-- stdout:go run github.com/hymkor/example-into-readme/cmd/badges@latest -->
+[![License](https://img.shields.io/badge/License-MIT-red)](https://github.com/hymkor/gqcs/blob/master/LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hymkor/gqcs.svg)](https://pkg.go.dev/github.com/hymkor/gqcs)
+[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/hymkor/gqcs)
+<!-- -->
+
 - A spreadsheet-like editor for your database, right in the terminal.
 - A standalone tool based on [SQL-Bless]&#x2019;s `edit` command.
 - Unlike SQL-Bless, GQuaccccccesS applies all edits automatically when you finish editing.


### PR DESCRIPTION
- Makefile:
    - Add `make readme` entry
    - Use `go run` instead of `minipage` binary executable
    - Use `go run` instead of `latest-notes.ps1`
    - Use `go run` instead of `make-scoop-manifest` binary executable
- README: Add badges